### PR TITLE
WIP

### DIFF
--- a/src/puppeteer/browserelement.ts
+++ b/src/puppeteer/browserelement.ts
@@ -558,6 +558,6 @@ export class BrowserElement extends PuppeteerElement implements iValue {
     selector: string = "*",
     suffix: string = ""
   ) {
-    return this.$.$x(`${prefix}${cssXPath(selector)}${suffix}`);
+    return this.$.$x(`//${prefix}${cssXPath(selector).slice(2)}${suffix}`);
   }
 }


### PR DESCRIPTION
This is working for `.getAncestor("a")` and `.getNextSibling(".num")`, but NOT for `.getFirstChild()` 

For the last, I still get 

```
child::undefined[1]
```

And I do not know why. Opening this PR for visibility, fixing #53 