### PR TITLE
Support all versions of cheerio

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -6,8 +6,8 @@ import {
 } from "./interfaces";
 import * as fs from "fs";
 import * as path from "path";
-import * as cheerio from "cheerio";
 import * as nodeAssert from "assert";
+const cheerio = require("cheerio");
 
 export const arrayify = <T>(value: any): T[] => {
   return toType(value) == "array" ? value : [value];
@@ -51,7 +51,10 @@ export function toType(obj: any): string {
     return "null";
   } else if (obj === NaN) {
     return "nan";
-  } else if (obj instanceof cheerio) {
+  } else if (
+    (typeof cheerio === "object" && obj instanceof cheerio.default) ||
+    (typeof cheerio === "function" && obj instanceof cheerio)
+  ) {
     return "cheerio";
   } else if (
     !!obj &&

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,7 +7,6 @@ import {
 import * as fs from "fs";
 import * as path from "path";
 import * as nodeAssert from "assert";
-const cheerio = require("cheerio");
 
 export const arrayify = <T>(value: any): T[] => {
   return toType(value) == "array" ? value : [value];
@@ -51,10 +50,7 @@ export function toType(obj: any): string {
     return "null";
   } else if (obj === NaN) {
     return "nan";
-  } else if (
-    (typeof cheerio === "object" && obj instanceof cheerio.default) ||
-    (typeof cheerio === "function" && obj instanceof cheerio)
-  ) {
+  } else if (!!obj && obj.cheerio) {
     return "cheerio";
   } else if (
     !!obj &&


### PR DESCRIPTION
Fixes #79 

Need to use `require` statement for access to `default` property

Access the constructor via `cheerio.default` if cheerio version is < `1.0.0-rc9`