### PR TITLE
Remove 100ms timeout from waitForHidden and waitForVisible

### DIFF
--- a/flagpole.json
+++ b/flagpole.json
@@ -161,6 +161,11 @@
       "id": "",
       "name": "waitForHavingText",
       "tags": []
+    },
+    "waitForVisible": {
+      "id": "",
+      "name": "waitForVisible",
+      "tags": []
     }
   }
 }

--- a/src/assertioncontext.ts
+++ b/src/assertioncontext.ts
@@ -299,7 +299,7 @@ export class AssertionContext implements iAssertionContext {
    */
   public async waitForHidden(
     selector: string,
-    timeout: number = 100
+    timeout?: number
   ): Promise<iValue> {
     const el: iValue = await this.response.waitForHidden(selector, timeout);
     el.isNull()
@@ -316,7 +316,7 @@ export class AssertionContext implements iAssertionContext {
    */
   public async waitForVisible(
     selector: string,
-    timeout: number = 100
+    timeout?: number
   ): Promise<iValue> {
     const el: iValue = await this.response.waitForVisible(selector, timeout);
     el.isNull()

--- a/src/puppeteer/browserresponse.ts
+++ b/src/puppeteer/browserresponse.ts
@@ -108,7 +108,7 @@ export class BrowserResponse extends PuppeteerResponse implements iResponse {
    */
   public async waitForHidden(
     selector: string,
-    timeout: number = 100
+    timeout?: number
   ): Promise<BrowserElement> {
     const opts = {
       timeout: this.getTimeoutFromOverload(timeout),
@@ -120,7 +120,7 @@ export class BrowserResponse extends PuppeteerResponse implements iResponse {
 
   public async waitForVisible(
     selector: string,
-    timeout: number = 100
+    timeout?: number
   ): Promise<BrowserElement> {
     const opts = {
       timeout: this.getTimeoutFromOverload(timeout),

--- a/tests/src/waitForVisible.ts
+++ b/tests/src/waitForVisible.ts
@@ -1,0 +1,25 @@
+import flagpole from "../../dist/index";
+
+const suite = flagpole("Basic Smoke Test of Site");
+
+suite
+  .scenario("Homepage Loads", "browser")
+  .open("https://www.w3schools.com/bootstrap/bootstrap_carousel.asp")
+  .next(async (context) => {
+    const before = Date.now();
+    await context.waitForVisible(".carousel-inner .item");
+    const after = Date.now();
+    const duration = after - before;
+    context.assert(duration).between(1, 30000);
+  });
+
+suite
+  .scenario("Wait for hidden", "browser")
+  .open("https://getbootstrap.com/docs/4.0/components/collapse/")
+  .next(async (context) => {
+    const before = Date.now();
+    await context.waitForHidden("#collapseExample");
+    const after = Date.now();
+    const duration = after - before;
+    context.assert(duration).between(1, 30000);
+  });


### PR DESCRIPTION
Remove the 100ms timeout from these methods and fallback on the default 30s instead.

Otherwise we have to specify something longer than 100ms 90% of the time.

This way, we only specify a timeout if we need the element to meet that criteria in a strict manner. 