### PR TITLE
Print actual value in HTML report

### DIFF
--- a/src/logging/logitem.ts
+++ b/src/logging/logitem.ts
@@ -39,7 +39,7 @@ export abstract class LogItem implements iLogItem {
     html += '<li class="${this.className}">';
     html += `<span class="message">${this.message}</span>`;
     if (this.failed) {
-      html += `<div>${this['detailsMessage']}</div>`
+      html += `<ul><li>${this['detailsMessage']}</li></ul>`
     }
     html += '</li>';
     return html;

--- a/src/logging/logitem.ts
+++ b/src/logging/logitem.ts
@@ -34,12 +34,15 @@ export abstract class LogItem implements iLogItem {
     return [new CustomLine(this.message, [255, 255, 255])];
   }
 
-  public toHtml(): string {
-    return `
-            <li class="${this.className}">
-                <span class="message">${this.message}</span>
-            </li>
-        `;
+  public toHtml(): string {    
+    let html: string = "";
+    html += '<li class="${this.className}">';
+    html += `<span class="message">${this.message}</span>`;
+    if (this.failed) {
+      html += `<div>${this['detailsMessage']}</div>`
+    }
+    html += '</li>';
+    return html;
   }
 
   public toJson(): any {


### PR DESCRIPTION
# HTML Fail Test Report

## Today's Behavior

Notice on the second screenshot, we do not get the actual value in the report. The `<li>` get the class `fail`, but we do not know why it failed. What was the actual value?

```
context.assert('one').equals(1)
```

![Screen Shot 2021-06-09 at 4 11 38 PM](https://user-images.githubusercontent.com/46609057/121422584-61724980-c93d-11eb-8cfb-81f1ffb8e970.png)

```
context.assert('1 equals 1', 'one').equals(1)
```

![Screen Shot 2021-06-09 at 4 13 17 PM](https://user-images.githubusercontent.com/46609057/121422834-9c747d00-c93d-11eb-8ee3-8f070c67ee5e.png)

## Desired Behavior

The actual value is shown:

![Screen Shot 2021-06-09 at 4 15 45 PM](https://user-images.githubusercontent.com/46609057/121423149-f5441580-c93d-11eb-99b2-151e60ad55a6.png)

## Notes

I know the bracket notation is not the prettiest, but I could not find the properties I needed on the `LogItem` class. `console.log(this)` in this method gave me an `AssertionFail` and the data I needed ( `detailsMessage` ) belonged to that class, so I borrowed it from there.

It there is a better way, please push me in the right direction, but for now, I am achieving the HTML report I need. 