### PR TITLE
Write XML Report to /tests/reports/

### DIFF
--- a/src/flagpoleconfig.ts
+++ b/src/flagpoleconfig.ts
@@ -46,6 +46,7 @@ export interface iProjectOpts {
   cache?: string;
   schemas?: string;
   pattern?: string;
+  reports?: string;
 }
 
 export interface iConfigOpts {
@@ -142,6 +143,7 @@ export class ProjectConfig {
   public cache: string;
   public schemas: string;
   public pattern: string;
+  public reports: string;
 
   public get isSourceAndOutput(): boolean {
     return this.source !== undefined && this.output !== undefined;
@@ -172,6 +174,7 @@ export class ProjectConfig {
     this.images = opts.images || "images";
     this.cache = opts.cache || "cache";
     this.schemas = opts.schemas || "schemas";
+    this.reports = opts.reports || "reports";
     this.source = opts.source;
     this.output = opts.output;
     this.pattern = opts.pattern || "";
@@ -198,6 +201,7 @@ export class ProjectConfig {
       images: this.images,
       cache: this.cache,
       schemas: this.schemas,
+      reports: this.reports
     };
   }
 }
@@ -293,6 +297,15 @@ export class FlagpoleConfig {
       path.join(this.getRootFolder(), this.project.cache || "cache")
     );
   }
+
+    /**
+   * Default; _project_/tests/reports
+   */
+     public getReportsFolder(): string {
+      return normalizePath(
+        path.join(this.getRootFolder(), this.project.reports || "reports")
+      );
+    }
 
   public getSuite(suiteName: string): SuiteConfig {
     return this.suites[suiteName];

--- a/src/flagpoleconfig.ts
+++ b/src/flagpoleconfig.ts
@@ -298,7 +298,7 @@ export class FlagpoleConfig {
     );
   }
 
-    /**
+  /**
    * Default; _project_/tests/reports
    */
      public getReportsFolder(): string {

--- a/src/logging/flagpolereport.ts
+++ b/src/logging/flagpolereport.ts
@@ -302,7 +302,6 @@ export class FlagpoleReport {
           // append the output and close the tag again
           report = `${noClosingTag}\n${report}\n</testsuites>`
           writeFileSync(reportPath, report)
-          process.send ? process.send(`Writing report to ${reportPath}`) : console.log(`Writing report to ${reportPath}`);
           resolve()
         } else if (err.code === 'ENOENT') {
           // if the file doesn't exist

--- a/src/logging/flagpolereport.ts
+++ b/src/logging/flagpolereport.ts
@@ -207,7 +207,7 @@ export class FlagpoleReport {
   public async print(): Promise<any> {
     return new Promise(async (resolve, reject) => {
       try {
-        let output = await this.toString();
+        const output = await this.toString();
 
         if (FlagpoleExecution.global.isXmlOutput) {
           // write the output to a file in the reports/ directory

--- a/src/logging/flagpolereport.ts
+++ b/src/logging/flagpolereport.ts
@@ -292,8 +292,8 @@ export class FlagpoleReport {
 
       readFile(reportPath, 'utf8', async (err, data) => {
 
-        // if the file exists
         if (err == null) {
+          // if the file exists
           // remove the </testsuites> tag 
           const fileLines = data.split('\n');
           fileLines.splice(fileLines.length - 1, 1);


### PR DESCRIPTION
Fixes #99 

The first commit writes a file with the format `MM-DD-YYYY-report.xml`

I would really like to use an execution or command id instead so we don't append runs that are ran on the same day in one report. Really, this is just for CI, but that would make sure future cases are respected as well in case somebody wants multiple daily XML reports persisting. Any ideas?