### PR TITLE
fix(interfaces): add executionOptions to iSuite

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -723,6 +723,7 @@ export interface iSuite {
   executionDuration: number | null;
   title: string;
   finished: Promise<void>;
+  executionOptions: FlagpoleExecution 
   import(scenario: iScenario): iScenario;
   subscribe(callback: SuiteStatusCallback): iSuite;
   verifyCert(verify: boolean): iSuite;

--- a/tests/src/test.ts
+++ b/tests/src/test.ts
@@ -1,4 +1,4 @@
-import flagpole from "flagpole";
+import flagpole from "../../dist/index";
 
 flagpole("Basic Smoke Test of Site", async (suite) => {
   suite


### PR DESCRIPTION
executionOptions is presented in the `Suite` class but not exposed via the interface so can't be used