### PR TITLE
HF: ci report join issue

### DIFF
--- a/src/logging/flagpolereport.ts
+++ b/src/logging/flagpolereport.ts
@@ -221,7 +221,9 @@ export class FlagpoleReport {
             ciOutput.push(`Suite: ${this.suite.title}`)
             ciOutput.push(`Scenario: ${scenario.title} - ${subScenarioTitle}`)
             ciOutput.push(`Assertion: ${message}`)
-            ciOutput.push(item['detailsMessage'].join(' - ').replace(/\s+/g, ' ').trim())
+            if (item['detailsMessage'] && item['detailsMessage'].length) {
+              ciOutput.push(item['detailsMessage'].join(' - ').replace(/\s+/g, ' ').trim())
+            }
           }
         }
       })


### PR DESCRIPTION
I found error:

```
(node:39126) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'join' of undefined
    at /Users/john.sickels/code/scorecard/node_modules/flagpole/dist/logging/flagpolereport.js:180:66
```

That's because there are not always `detailsMessage`. The conditional will catch this.