### PR TITLE
Improve test output

### DIFF
--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -104,18 +104,6 @@ export default class Run extends Command {
     }
     // Now run them
     if (selectedSuites.length) {
-      if (FlagpoleExecution.global.shouldOutputToConsole) {
-        Cli.log(
-          "",
-          selectedSuites.length === 1 ? "Running Suite:" : "Running Suites: ",
-          selectedSuites
-            .map((suite) => {
-              return suite.name;
-            })
-            .join(", "),
-          ""
-        );
-      }
       return runSuites(selectedSuites, !!args.async, !!args.keepCache);
     }
     // None to run
@@ -238,6 +226,11 @@ const runSuites = async (
       runner.after(() => {
         spinner.stop();
         Ansi.write(Ansi.eraseLines(2));
+      });
+    } else {
+      // print the status of what suite we are running, but without the spinner
+      runner.subscribe((message: string) => {
+        Ansi.writeLine(Ansi.cursorUp(), Ansi.eraseLine(), message);
       });
     }
   }

--- a/src/cli/testrunner.ts
+++ b/src/cli/testrunner.ts
@@ -3,6 +3,7 @@ import { Cli } from "./cli";
 import { SuiteExecution, SuiteExecutionResult } from "./suiteexecution";
 import { FlagpoleExecution } from "..";
 import { SuiteExecutionInline } from "./suiteexecutioninline";
+import Ansi from "cli-ansi";
 
 export class TestRunner {
   private _suiteConfigs: { [s: string]: SuiteConfig } = {};
@@ -174,7 +175,10 @@ export class TestRunner {
             `;
     } else if (FlagpoleExecution.global.isCiOutput) {
       this._executionResults.forEach((result) => {
-        output += result.toString() + "\n\n";
+        const stringifiedResult = result.toString();
+        if (stringifiedResult) {
+          output += stringifiedResult + "\n\n";
+        }
       });
     } else {
       this._executionResults.forEach((result) => {
@@ -231,12 +235,17 @@ export class TestRunner {
       Cli.exit(this.allPassing ? 0 : 1);
     } else if (FlagpoleExecution.global.isCiOutput) {
       const overall = this._getSummary();
-      Cli.log(`---SUMMARY---`);
+
+      // erase the last "Running suite a ( x of y )"
+      Ansi.writeLine(Ansi.cursorUp(), Ansi.eraseLine());
+
+      Cli.subheader("SUMMARY");
       Cli.log(`Passed: ${overall.pass}`);
       Cli.log(`Failed: ${overall.fail}`);
       Cli.log(`Duration: ${overall.duration}ms`);
       Cli.log("\n");
       Cli.log(output);
+      Cli.exit(this.allPassing ? 0 : 1);
     } else {
       Cli.log(output);
       if (!this.allPassing && FlagpoleExecution.global.shouldOutputToConsole) {


### PR DESCRIPTION
Old:
```
[\] Running suite testA (1 of 3)...
[-] Running suite testB (2 of 3)...
[/] Running suite testC (3 of 3)...

Running suites: testA, testB, testC
```
Old CI:
```
Running suites: testA, testB, testC
```
---
New:
```
[\] Running suite testA (1 of 3)...
[-] Running suite testB (2 of 3)...
[/] Running suite testC (3 of 3)...
```
New CI:
```
Running suite testA (1 of 3)...
Running suite testB (2 of 3)...
Running suite testC (3 of 3)...
```

The benefit here, is that if the spinner is off and the execution gets stuck, I get to know on which suite. The local CLI will overwrite each line so you will only see one `Running suite...` at a time, but CI output prints each one. 

- Remove the redundant `Running suites: testA, testB, testC`
- Include a new subscription if `shouldOutputToConsole` is true and we don't hit the spinner
- Make a couple spacing tweaks