### PR TITLE
Add maxLoadTime argument for templates

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1055,4 +1055,5 @@ export interface ScenarioInitOptions {
   maxRedirects?: number;
   next?: iNextCallback;
   statusCode?: number;
+  maxLoadTime?: number;
 }

--- a/src/suite.ts
+++ b/src/suite.ts
@@ -508,6 +508,13 @@ export class Suite implements iSuite {
           context.assert(context.response.statusCode).equals(opts.statusCode);
         });
       }
+      if (opts.maxLoadTime) {
+        scenario.next((context) => {
+          context
+            .assert(context.response.loadTime)
+            .lessThanOrEquals(opts.maxLoadTime);
+        });
+      }
       if (opts.next) scenario.next(opts.next);
       return scenario;
     };


### PR DESCRIPTION
I am starting to think about how to incorporate performance testing more into Flagpole. When we use a template we may want to ensure that all calls come back in under a certain amount of time. This makes it easy to add that test to everything generated from that template.