### PR TITLE
Added check for element with length of 0

### DIFF
--- a/src/html/htmlelement.ts
+++ b/src/html/htmlelement.ts
@@ -76,10 +76,7 @@ export class HTMLElement extends DOMElement implements iValue {
       if (params.contains || params.matches) {
       } else {
         const element = this.el.find(selector).eq(0);
-        if (element.length === 0) {
-          return this._wrapAsValue(null, name);
-        }
-        if (element !== null) {
+        if (element?.length) {
           return HTMLElement.create(element, this._context, name, path);
         }
       }


### PR DESCRIPTION
This resolves an issue where if an HTML element is not found, a test will crash with a TypeError. Now if the element is not found, a Value with null will be returned.