### PR TITLE
Escape ltgt in docsify md

### DIFF
--- a/docs/assertion-context.md
+++ b/docs/assertion-context.md
@@ -82,7 +82,7 @@ context.assert(await context.find("article.topStory h1")).exists();
 
 You can also pass a message as the first argument, which will override the default assertion message.
 
-### clear(selector: string): Promise<void>
+### clear(selector: string): Promise\<void\>
 
 Clear the existing text in this input and then type this text into the selected path.
 
@@ -90,7 +90,7 @@ Clear the existing text in this input and then type this text into the selected 
 await context.clear('input[name="q"]');
 ```
 
-### clearThenType(path: string, textToType: string, opts: any): Promise<void>
+### clearThenType(path: string, textToType: string, opts: any): Promise\<void\>
 
 Clear the existing text in this input and then type this text into the selected path. For browser scenarios this will be emulating literally pressing keys into the browser. For HTML scenarios it overwrite the value of that element.
 
@@ -104,13 +104,13 @@ Issues a click on the selected element. This works on both browser and html type
 
 There are a few forms of this
 
-#### click(selector: string): Promise<void>
+#### click(selector: string): Promise\<void\>
 
 ```javascript
 await context.click('input[name="q"]');
 ```
 
-#### click(selector: string, message: string): Promise<iScenario>
+#### click(selector: string, message: string): Promise\<iScenario\>
 
 This will select the object and, if it is a clickable element (like a link), it will create a new dynamic scenario with that URL loaded.
 
@@ -122,7 +122,7 @@ context.click('a.login', 'Load login page')).next((loginContext) => {
 
 It returns a promise that resolves to the dynamic scenario.
 
-#### click(selector: string, callback: Function): Promise<iScenario>
+#### click(selector: string, callback: Function): Promise\<iScenario\>
 
 Alternately, you can pass a callback for the dynamic scenario as the second argument. The title of the scenario will be automatically created.
 
@@ -132,7 +132,7 @@ await context.click("a.login", (loginContext) => {
 });
 ```
 
-#### click(selector: string, message: string, callback: Function): Promise<iScenario>
+#### click(selector: string, message: string, callback: Function): Promise\<iScenario\>
 
 Or combine the two methods with a message and callback.
 
@@ -142,7 +142,7 @@ context.click("a.login", "Load login page", (loginContext) => {
 });
 ```
 
-#### click(selector: string, subScenario: iScenario): Promise<iScenario>
+#### click(selector: string, subScenario: iScenario): Promise\<iScenario\>
 
 Finally if you have a scenario already and you want to execute it with the link from the element, pass in the reference to that scenario.
 
@@ -166,9 +166,9 @@ context.comment(context.response.body);
 context.comment(json.data);
 ```
 
-### exists(): Promise<iValue>
+### exists(): Promise\<iValue\>
 
-#### exists(selector: string): Promise<iValue>
+#### exists(selector: string): Promise\<iValue\>
 
 This is just like an `find`, but it also does an assertion that the element actually exists. It is similar to `waitForExists` except that it doesn't wait around.
 
@@ -184,7 +184,7 @@ Or you can grab the element that it returns:
 const firstArticle = await context.exists("section.topStories article");
 ```
 
-#### exists(selector: string, contains: string): Promise<iValue>
+#### exists(selector: string, contains: string): Promise\<iValue\>
 
 Pass in a third argument as a string to test whether the item exists that contains this text.
 
@@ -196,7 +196,7 @@ await context.exists(
 );
 ```
 
-#### exists(selector: string, mathces: RegExp): Promise<iValue>
+#### exists(selector: string, mathces: RegExp): Promise\<iValue\>
 
 This third argument can alternately be a regular expression:
 
@@ -208,7 +208,7 @@ await context.exists(
 );
 ```
 
-#### exists(selector: string, contains: string | RegExp, opts: FindOps): Promise<iValue>
+#### exists(selector: string, contains: string | RegExp, opts: FindOps): Promise\<iValue\>
 
 As a fourth argument, you can include any of the `opts` properties from `find()`, for example:
 
@@ -234,7 +234,7 @@ await context.exists(
 
 The `exists` method will return the matched element inside of the iValue or a null iValue if there is no match.
 
-#### exists(selectors: string[]): Promise<iValue>
+#### exists(selectors: string[]): Promise\<iValue\>
 
 With any variation of `exists`, your first agument can also be an array of selectors. Passing in more than one element for the array will make sure that at least one of them exists, and it will return the first one that does.
 
@@ -271,7 +271,7 @@ This works just like `existsAll`, except that it only asserts that at least one 
 const buttons = await context.existsAny(["button", "div.button"]);
 ```
 
-### evaluate(callback: Function): Promise<any>
+### evaluate(callback: Function): Promise\<any\>
 
 Passes this function off to the underlying response to run it in the context of that type.
 
@@ -303,9 +303,9 @@ const loginText = await context.evaluate((json) => {
 
 In theory, with any of these types, you could also manipulate the response with this method.
 
-### find(): Promise<iValue>
+### find(): Promise\<iValue\>
 
-#### find(selector: string, opts?: FindOpts): Promise<iValue>
+#### find(selector: string, opts?: FindOpts): Promise\<iValue\>
 
 Select the first matching element or value at the given path. What this actually does varies by the type of scenario.
 
@@ -323,7 +323,7 @@ const secondArticle = await context.find("section.topStories article", {
 });
 ```
 
-#### find(selector: string, contents: string, opts?: FindOpts): Promise<iValue>
+#### find(selector: string, contents: string, opts?: FindOpts): Promise\<iValue\>
 
 Find the first element matching the given selector that have the given text. The second argument is a string of the text we are looking for the element to contain
 
@@ -339,7 +339,7 @@ const buttonWithYesValue = await context.find("button", "Yes", {
 });
 ```
 
-#### find(selector: string, matches: RegExp, opts?: FindOpts): Promise<iValue>
+#### find(selector: string, matches: RegExp, opts?: FindOpts): Promise\<iValue\>
 
 Similar to the previous overload of `find`, we can also search the contents of the element for one that matches a regular expression. This gives us greater control over how exactly it should match, such as matching capitalization and spacing.
 
@@ -353,7 +353,7 @@ So if you want it to match EXACTLY "Yes", including a capital "Y" and no spaces 
 const buttonExactlyYes = await context.find("button", /^Yes$/);
 ```
 
-#### find(selectors: string[]): Promise<iValue>
+#### find(selectors: string[]): Promise\<iValue\>
 
 With any of the above variations, selector can also be an array of strings. This will cause `find` to look for the first instance of ANY of those selector paths.
 
@@ -361,13 +361,13 @@ With any of the above variations, selector can also be an array of strings. This
 const firstButtonLikeThing = await context.find(["button", ".button"]);
 ```
 
-### findAll(): Promise<iValue[]>
+### findAll(): Promise\<iValue[]\>
 
 Select the elements or values at the given path. What this actually does varies by the type of scenario.
 
 This always returns an array. It will be an empty array if nothing matched. The array elements themselves will be the same object types that you'd have gotten from `.find()`.
 
-#### findAll(selector: string, opts?: FindAllOpts): Promise<iValue[]>
+#### findAll(selector: string, opts?: FindAllOpts): Promise\<iValue[]\>
 
 The first argument is always the selector. It is the only required argument.
 
@@ -389,7 +389,7 @@ const articles = await context.findAll("section.headlines article", {
 });
 ```
 
-#### findAll(selector: string, contains: string, opts?: FindAllOpts): Promise<iValue[]>
+#### findAll(selector: string, contains: string, opts?: FindAllOpts): Promise\<iValue[]\>
 
 This overload will allow you to search for only elements that match the selector AND have the contains string in the text node.
 
@@ -399,7 +399,7 @@ const articles = await context.findAll("section.headlines article", "breaking");
 
 The optional `opts` argument allows you to use `offset`, `limit` and `findBy` (which works just like in the `find()` method).
 
-#### findAll(selector: string, matches: RegExp, opts?: FindAllOpts): Promise<iValue[]>
+#### findAll(selector: string, matches: RegExp, opts?: FindAllOpts): Promise\<iValue[]\>
 
 This works like the `contains` string, except you can use a regular expression for more exacting matches.
 
@@ -407,7 +407,7 @@ This works like the `contains` string, except you can use a regular expression f
 const itemsContainingTupac = await context.findAll("li", /tupac/i);
 ```
 
-#### findAll(selectors: string[]): Promise<iValue[]>
+#### findAll(selectors: string[]): Promise\<iValue[]\>
 
 With any of the above variations of `findAll`, the first argument can also be an array of strings. If you pass in more than one, the resulting response will include any items that match any of those selectors.
 
@@ -415,7 +415,7 @@ With any of the above variations of `findAll`, the first argument can also be an
 const allButtonLikeThings = await context.findAll(["button", ".button"]);
 ```
 
-### findAllXPath(xPath: string): Promise<DOMElement[]>
+### findAllXPath(xPath: string): Promise\<DOMElement[]\>
 
 Checks for any and all elements at XPath of `xPath`. Usually a CSS selector is preferable, but sometimes XPath is more powerful. This only works with Puppetteer tests currently.
 
@@ -423,7 +423,7 @@ Checks for any and all elements at XPath of `xPath`. Usually a CSS selector is p
 const links = await context.findAllXpath("//a");
 ```
 
-### findXPath(xPath: string): Promise<DOMElement>
+### findXPath(xPath: string): Promise\<DOMElement\>
 
 Checks for an element to exist with XPath of `xPath`. Usually a CSS selector is preferable, but sometimes XPath is more powerful. This only works with Puppeteer test currently.
 
@@ -448,7 +448,7 @@ scenario
   });
 ```
 
-### openInBrowser(): Promise<string>
+### openInBrowser(): Promise\<string\>
 
 Saves the response body to a temporary file and opens it in a browser. This is really only for debugging. The promise resolves to the string of the temporary file.
 
@@ -456,7 +456,7 @@ Saves the response body to a temporary file and opens it in a browser. This is r
 await context.openInBrowser();
 ```
 
-### pause(milleseconds: number): Promise<void>
+### pause(milleseconds: number): Promise\<void\>
 
 Delay the execution by this much.
 
@@ -464,7 +464,7 @@ Delay the execution by this much.
 await context.pause(1000);
 ```
 
-### screenshot(): Promise<Buffer>
+### screenshot(): Promise\<Buffer\>
 
 Takes a screenshot of that point in time. Currently this is only supported in a browser-based scenario. The return value is a promise that resolves with a Buffer of the image bytes.
 
@@ -497,7 +497,7 @@ const screenshot = await context.screenshot("/path/to/local/file.png", {
 });
 ```
 
-### scrollTo({ x?: number, y?: number }): Promise<void>
+### scrollTo({ x?: number, y?: number }): Promise\<void\>
 
 For browser-based tests this will scroll to these coordinates on the page body. Both `x` and `y` properties are optional and will be assumed as `0` if not set.
 
@@ -505,7 +505,7 @@ For browser-based tests this will scroll to these coordinates on the page body. 
 await context.scrollTo({ y: 500 });
 ```
 
-### selectOption(selector: string, value: string | string[]): Promise<string[]>
+### selectOption(selector: string, value: string | string[]): Promise\<string[]\>
 
 Select items in a dropdown or multi-select box.
 
@@ -517,13 +517,13 @@ await context.select('select[name="favoriteSport"]', "Track & Field");
 
 Save `value` to alias `aliasName` so it that it can be retrieved later with a `.get(aliasName)` call.
 
-### submit(selector: string, ...): Promise<iScenario | void>
+### submit(selector: string, ...): Promise\<iScenario | void\>
 
 Submits the form, if the selected element is a form. This works on both browser and html types. For browser, it will do whatever submitting the form would do in the browser window. For html scenarios, it will serialize the form input and then submit it, navigating to the next page.
 
 Other than that, it works mostly the same as a `click()`.
 
-### type(path: string, textToType: string, opts: any): Promise<void>
+### type(path: string, textToType: string, opts: any): Promise\<void\>
 
 Type this text into the selected path. For browser scenarios this will be emulating literally typing into the browser. For HTML scenarios it set the value of that element.
 
@@ -531,7 +531,7 @@ Type this text into the selected path. For browser scenarios this will be emulat
 await context.type('input[name="q"]', "who shot 2pac?");
 ```
 
-### waitForReady(timeout: number = 10000): Promise<void>
+### waitForReady(timeout: number = 10000): Promise\<void\>
 
 Wait for `timeout` milliseconds for the browser's navigation to complete. This really only makes sense in a browser-based scenario. This is shorthand for the `domcontentloaded` in the Puppeteer API.
 
@@ -539,7 +539,7 @@ Wait for `timeout` milliseconds for the browser's navigation to complete. This r
 await context.waitForReady();
 ```
 
-### waitForExists(path: string, timeout: number): Promise<DOMElement>
+### waitForExists(path: string, timeout: number): Promise\<DOMElement\>
 
 Test if an element exists at that path. For a browser scenario it will wait a certain timeout (default 100ms) for the element to show up. If you want it to wait longer, set the timeout value in the second argument.
 
@@ -547,7 +547,7 @@ Test if an element exists at that path. For a browser scenario it will wait a ce
 const button = await context.waitForExists("a.submit", 2000);
 ```
 
-### waitForHavingText(path: string, text, timeout?: number): Promise<DOMElement>
+### waitForHavingText(path: string, text, timeout?: number): Promise\<DOMElement\>
 
 Checks for an element to exist at `path` CSS selector, which also contains the string `text` inside of its `innerText`. By default it will wait for 100ms for the element, you can change the timeout with the third argument.
 
@@ -555,7 +555,7 @@ Checks for an element to exist at `path` CSS selector, which also contains the s
 await context.waitForHavingText("h1", "Features", 2000);
 ```
 
-### waitForHidden(path: string): Promise<DOMElement>
+### waitForHidden(path: string): Promise\<DOMElement\>
 
 Checks if an element at this selector is hidden (display none or visibility hidden). This only makes sense for browser tests, it will error for other types of scenario. By default it will wait for 100ms for the element to show up, you can change the timeout with the second argument.
 
@@ -563,7 +563,7 @@ Checks if an element at this selector is hidden (display none or visibility hidd
 const button = await context.waitForHidden('button[type="submit"]', 2000);
 ```
 
-### waitForLoad(timeout: number = 10000): Promise<void>
+### waitForLoad(timeout: number = 10000): Promise\<void\>
 
 Wait for `timeout` milliseconds for the browser's navigation to complete. This really only makes sense in a browser-based scenario. This is shorthand for the `load` in the Puppeteer API.
 
@@ -571,7 +571,7 @@ Wait for `timeout` milliseconds for the browser's navigation to complete. This r
 await context.waitForLoad(15000);
 ```
 
-### waitForNetworkIdle(timeout: number = 10000): Promise<void>
+### waitForNetworkIdle(timeout: number = 10000): Promise\<void\>
 
 Wait for `timeout` milliseconds for the browser's navigation to complete. This really only makes sense in a browser-based scenario. This is shorthand for the `networkidle0` in the Puppeteer API.
 
@@ -579,7 +579,7 @@ Wait for `timeout` milliseconds for the browser's navigation to complete. This r
 await context.waitForNetworkIdle(5000);
 ```
 
-### waitForNavigation(timeout: number = 10000, waitFor?: string | string[]): Promise<void>
+### waitForNavigation(timeout: number = 10000, waitFor?: string | string[]): Promise\<void\>
 
 Wait for `timeout` milliseconds for the browser's navigation to complete. This really only makes sense in a browser-based scenario.
 
@@ -591,7 +591,7 @@ await context.waitForNavigation();
 await context.exists("h1.headline");
 ```
 
-### waitForVisible(path: string): Promise<DOMElement>
+### waitForVisible(path: string): Promise\<DOMElement\>
 
 Checks if an element at this selector is visible. This only makes sense for browser tests, it will error for other types of scenario. By default it will wait for 100ms for the element to show up, you can change the timeout with the second argument.
 
@@ -599,7 +599,7 @@ Checks if an element at this selector is visible. This only makes sense for brow
 const button = await context.waitForVisible('button[type="submit"]', 2000);
 ```
 
-### waitForXpath(xPath: string, timeout?: number): Promise<DOMElement>
+### waitForXpath(xPath: string, timeout?: number): Promise\<DOMElement\>
 
 Checks for an element to exist with XPath of `path`. Usually a CSS selector is preferable, but sometimes XPath is more powerful. By default it will wait for 100ms for the element, you can change the timeout with the second argument.
 

--- a/docs/assertion.md
+++ b/docs/assertion.md
@@ -100,7 +100,7 @@ context.assert(myValue).equals(5);
 
 If the values are objects it will test for a deep-equals with standard quality checks. If the values are arrays, it will check each array item.
 
-### every(callback: Function): Promise<Assertion>
+### every(callback: Function): Promise\<Assertion\>
 
 Loops throught the input value, which should be an array, and checks them against the callback function to be sure that every one is true.
 
@@ -270,7 +270,7 @@ context.assert(jsonData).matches({
 
 The above example schema evaluates for matching types, not values.
 
-### none(callback: Function): Promise<Assertion>
+### none(callback: Function): Promise\<Assertion\>
 
 Loops throught the input value, which should be an array, and checks them against the callback function to be sure that none are true.
 
@@ -315,7 +315,7 @@ Tests whether the input promise resolves.
 await context.assert(myPromise).resolves();
 ```
 
-### schema(schema: Schema, schemaType?: "JsonSchema" | "JTD"): Promise<Assertion>
+### schema(schema: Schema, schemaType?: "JsonSchema" | "JTD"): Promise\<Assertion\>
 
 Test whether the input matches the schema provided. This is only valid for testing JSON. This assertion is async (returns a promise) so you should either await it or return it at the end of a next block. Flagpole supports two specifications: JSON Schema and JSON Type Definition ("JTD"). The default is "JsonSchema".
 
@@ -325,7 +325,7 @@ Either way, the syntax to make the assertion will be the same:
 await context.assert(jsonResponse).schema(mySchema);
 ```
 
-### schema(shemaPath: string, schemaType?: "JsonSchema" | "JTD")): Promise<Assertion>
+### schema(shemaPath: string, schemaType?: "JsonSchema" | "JTD")): Promise\<Assertion\>
 
 Pass in a name or path of a schema to check against. The first time you run this assertion (or if the file doesn't exist), it will PASS the test and CREATE the schema file for you from a snapshot of the current JSON response. This makes it trivial to create your control schema to test against on future runs.
 
@@ -343,7 +343,7 @@ But if you start the path with `@` then you only need to provide a name. This wi
 await context.assert(context.response.jsonBody).schema("@article-list");
 ```
 
-### some(callback: Function): Promise<Assertion>
+### some(callback: Function): Promise\<Assertion\>
 
 Loops throught the input value, which should be an array, and checks them against the callback function to be sure that at least one is true.
 

--- a/docs/ivalue.md
+++ b/docs/ivalue.md
@@ -167,7 +167,7 @@ If the input is an array of objects, the argument then should be the key of the 
 const averagePrice = rows.sum("price");
 ```
 
-### clear(): Promise<void>
+### clear(): Promise\<void\>
 
 Clear any text input into this form. This will not have any effect if the element is not a form text input.
 
@@ -176,15 +176,15 @@ const textBox = await context.find('input[name="title"]');
 await textBox.clear();
 ```
 
-### clearThenType(textToType: string, opts: any): Promise<void>
+### clearThenType(textToType: string, opts: any): Promise\<void\>
 
 Literally calls clear() and then type() methods. So just a shorthand to clear out the exiting text first before typing.
 
-### click(): Promise<void>
+### click(): Promise\<void\>
 
 If the DOM Element is something clickable like a link or a button, you can perform a "click" on it. There are multiple options for loverloading it.
 
-#### click(message: string, callback: function): Promise<void>
+#### click(message: string, callback: function): Promise\<void\>
 
 You can specify a message, which will become the sub-scenario title, and a callback. This will effectively create a new lambda scenario.
 
@@ -195,7 +195,7 @@ loginLink.click("Make sure link is valid", (subContext) => {
 });
 ```
 
-#### click(callback: function): Promise<void>
+#### click(callback: function): Promise\<void\>
 
 If you leave off the message it still works. This will set the sub-scenario title to the URL you are opening.
 
@@ -206,7 +206,7 @@ loginLink.click((subContext) => {
 });
 ```
 
-#### click(otherScenario: Scenario): Promise<void>
+#### click(otherScenario: Scenario): Promise\<void\>
 
 Alternately, you can pre-define another scenario you want to execute on this click. Just leave the `open` method off of that scenario definition. Calling click on this link will call open with this URL to kick off that other scenario.
 
@@ -215,7 +215,7 @@ const loginLink = await context.find("a.login");
 loginLink.click(otherScenario);
 ```
 
-#### click(): Promise<void>
+#### click(): Promise\<void\>
 
 Finally, you can leave off all of the arguments. This will execute a click with a basic scenario, which sometimes will be sufficient for a basic test of a valid link.
 
@@ -278,7 +278,7 @@ With an argument for key, it will sort as an array of objects by that field.
 const reverseAlphaUsStates = usStates.desc("name");
 ```
 
-### download(): Promise<string | Buffer | null>
+### download(): Promise\<string | Buffer | null\>
 
 This will download the URL that is referenced by this element. It will automatically pull the `src` attribute from an `img` tag, for example. Or extract the `href` from a link.
 
@@ -362,9 +362,9 @@ Loop through the array or object items and make sure all return true.
 const allAreActive = rows.every((row) => row.isActive);
 ```
 
-### exists(): Promise<iValue>
+### exists(): Promise\<iValue\>
 
-#### exists(): Promise<iValue>;
+#### exists(): Promise\<iValue\>;
 
 With no arguments, you are making an assertion that this element exists. That is, it is not `null` or `undefined`. An assertion message is automatically generated based on the original selector.
 
@@ -373,7 +373,7 @@ const h1 = await context.find("h1");
 await h1.exists();
 ```
 
-#### exists(message: string): Promise<iValue>;
+#### exists(message: string): Promise\<iValue\>;
 
 You can alternately specify a custom asertion message:
 
@@ -390,9 +390,9 @@ const h1 = await context.exists("There should be an H1 tag", "h1");
 
 But there may be situations where you already have an element from another type of method and want to make sure it exists.
 
-### fillForm(): Promise<Value>
+### fillForm(): Promise\<Value\>
 
-#### fillForm(data: { [key: string]: any }): Promise<Value>
+#### fillForm(data: { [key: string]: any }): Promise\<Value\>
 
 Fill out a form element with this data. The data object should match the input/select name attributes of elements within the form. For multi-select inputs pass in an array of values to be checked.
 
@@ -408,7 +408,7 @@ await form.fillForm({
 });
 ```
 
-#### fillForm(attributeName: string, data: { [key: string]: any }): Promise<Value>
+#### fillForm(attributeName: string, data: { [key: string]: any }): Promise\<Value\>
 
 This works just like the single-argument overload, except that you can specify the attribute name. The default is to search in the `name` attribute, but in some cases you may want to use a different field such as `id` or `ng-reflect-name` or antyhing else.
 
@@ -428,7 +428,7 @@ Loop through the array or object items and filter the input;
 const activeRows = rows.filter((row) => row.isActive);
 ```
 
-### find(selector: string): Promise<iValue>
+### find(selector: string): Promise\<iValue\>
 
 Find the first element in the descendents of the current element that matches this selector. If there are no matches, you will be returned a Value object that contains null.
 
@@ -438,7 +438,7 @@ const li = await someElement.find("li");
 
 There are additional overloads for this method. For more details see the documentation in `AssertionContext` because it works the same way.
 
-### findAll(selector: string): Promise<iValue>
+### findAll(selector: string): Promise\<iValue\>
 
 Find all of the elements in the descendents of the current element that match this selector. If there are no matches, it will be an empty array.
 
@@ -448,11 +448,11 @@ const li = await someElement.findAll("li");
 
 There are additional overloads for this method. For more details see the documentation in `AssertionContext` because it works the same way.
 
-### focus(): Promise<any>;
+### focus(): Promise\<any\>;
 
 Give this element focus.
 
-### getAttribute(key: string): Promise<Value>
+### getAttribute(key: string): Promise\<Value\>
 
 Get the attribute of the element with this key and return its value. If it is not present the Value object will contain null.
 
@@ -460,11 +460,11 @@ Get the attribute of the element with this key and return its value. If it is no
 const src = await img.getAttribute("src");
 ```
 
-### getBounds(boxType: string): Promise<iBounds | null>;
+### getBounds(boxType: string): Promise\<iBounds | null\>;
 
 Get the bounds of this DOM Element.
 
-### getChildren(selector?: string): Promise<DOMElement[]>
+### getChildren(selector?: string): Promise\<DOMElement[]\>
 
 Get the immediate children of the current element. If a selector string is passed, it will filter only children matching that selector. If none match the selector, an empty array will be returned.
 
@@ -472,7 +472,7 @@ Get the immediate children of the current element. If a selector string is passe
 const children = await someElement.getChildren("li");
 ```
 
-### getClassName(): Promise<Value>
+### getClassName(): Promise\<Value\>
 
 Get the class name of this element. If there are multiple classes then they will be space delimited.
 
@@ -480,7 +480,7 @@ Get the class name of this element. If there are multiple classes then they will
 const className = await someElement.getClassName();
 ```
 
-### getInnerHtml(): Promise<Value>
+### getInnerHtml(): Promise\<Value\>
 
 Get the child HTML tags that are between the opening and closing tag of this element.
 
@@ -488,7 +488,7 @@ Get the child HTML tags that are between the opening and closing tag of this ele
 const html = await someElement.getInnerHtml();
 ```
 
-### getInnerText(): Promise<Value>
+### getInnerText(): Promise\<Value\>
 
 Get the text inside the opening and closing tags of the given element.
 
@@ -496,7 +496,7 @@ Get the text inside the opening and closing tags of the given element.
 const text = await someElement.getInnerText();
 ```
 
-### getNextSibling(selector?: string): Promise<DOMElement | Value<null>>
+### getNextSibling(selector?: string): Promise\<DOMElement | Value\<null\>\>
 
 Traverse through the siblings proceeding the current element. If no selector is passed, the immediate following sibling is returned. If a selector is passed, the next one matching the selector is returned. If none match, a Value object containing null is returned.
 
@@ -504,7 +504,7 @@ Traverse through the siblings proceeding the current element. If no selector is 
 const nextSibling = await someElement.getNextSibling("li");
 ```
 
-### getNextSiblings(selector?: string): Promise<DOMElement[]>
+### getNextSiblings(selector?: string): Promise\<DOMElement[]\>
 
 Traverse through the siblings proceeding the current element. If no selector is passed, all next siblings will be returned. If a selector is passed, only those matching the selector. If none match, an empty array is returned.
 
@@ -512,7 +512,7 @@ Traverse through the siblings proceeding the current element. If no selector is 
 const siblings = await someElement.getNextSiblings("li");
 ```
 
-### getOuterHtml(): Promise<Value>
+### getOuterHtml(): Promise\<Value\>
 
 Get the HTML string of the current element and all of its child elemenets from the opening of the tag to the ending of the tag.
 
@@ -520,7 +520,7 @@ Get the HTML string of the current element and all of its child elemenets from t
 const html = await someElement.getOuterHtml();
 ```
 
-### getPreviousSibling(selector?: string): Promise<DOMElement | Value<null>>
+### getPreviousSibling(selector?: string): Promise\<DOMElement | Value\<null\>\>
 
 Traverse through the siblings preceeding the current element. If no selector is passed, the immediate preceeding sibling is returned. If a selector is passed, the previous one matching the selector is returned. If none match, a Value object containing null is returned.
 
@@ -528,7 +528,7 @@ Traverse through the siblings preceeding the current element. If no selector is 
 const prevSibling = await someElement.getPreviousSibling("li");
 ```
 
-### getPreviousSiblings(selector?: string): Promise<DOMElement[]>
+### getPreviousSiblings(selector?: string): Promise\<DOMElement[]\>
 
 Traverse through the siblings preceeding the current element. If no selector is passed, all previous siblings will be returned. If a selector is passed, only those matching the selector. If none match, an empty array is returned.
 
@@ -536,7 +536,7 @@ Traverse through the siblings preceeding the current element. If no selector is 
 const siblings = await someElement.getPreviousSiblings("li");
 ```
 
-### getProperty(key: string): Promise<Value>
+### getProperty(key: string): Promise\<Value\>
 
 Get the property of this input value with the key. If there is no such property then it will return null. This is an async method.
 
@@ -544,7 +544,7 @@ Get the property of this input value with the key. If there is no such property 
 const isChecked = await element.getProperty("checked");
 ```
 
-### getSiblings(selector?: string): Promise<DOMElement[]>
+### getSiblings(selector?: string): Promise\<DOMElement[]\>
 
 Get the siblings of the current element. If a selector string is passed, it will filter only siblings matching that selector. If none match, it will return an empty array.
 
@@ -552,7 +552,7 @@ Get the siblings of the current element. If a selector string is passed, it will
 const siblings = await someElement.getSiblings("li");
 ```
 
-### getTagName(): Promise<Value>
+### getTagName(): Promise\<Value\>
 
 Get the HTML tag of this element.
 
@@ -560,7 +560,7 @@ Get the HTML tag of this element.
 const tagName = await someElement.getTagName();
 ```
 
-### getText(): Promise<Value>
+### getText(): Promise\<Value\>
 
 Get the textContent of this element. This is slightly different from getInnerText() and here is a [StackOverflow question](https://stackoverflow.com/questions/35213147/difference-between-textcontent-vs-innertext) about that so I don't have to repeat it.
 
@@ -568,7 +568,7 @@ Get the textContent of this element. This is slightly different from getInnerTex
 const text = await div.getText();
 ```
 
-### getValue(): Promise<Value>
+### getValue(): Promise\<Value\>
 
 Get the value of this element. This is normally used with form elements.
 
@@ -584,7 +584,7 @@ Loops through the input array of objects and returns a new iValue with an object
 const eventsByCountry = events.groupBy("venueCountry");
 ```
 
-### hasAttribute(key: string): Promise<Value>
+### hasAttribute(key: string): Promise\<Value\>
 
 Does this element have an attribute by this name?
 
@@ -592,7 +592,7 @@ Does this element have an attribute by this name?
 context.assert(await img.hasAttribute("src")).equals(true);
 ```
 
-### hasClassName(className: string): Promise<Value>
+### hasClassName(className: string): Promise\<Value\>
 
 Does this element have the given class? The value will contain boolean.
 
@@ -600,7 +600,7 @@ Does this element have the given class? The value will contain boolean.
 context.assert(await element.hasClassName("heading")).equals(true);
 ```
 
-### hasData(key: string): Promise<Value>
+### hasData(key: string): Promise\<Value\>
 
 Does this element have a data property by this name?
 
@@ -608,7 +608,7 @@ Does this element have a data property by this name?
 context.assert(await element.hasData("athlete-id")).equals(true);
 ```
 
-### hasProperty(key: string): Promise<Value>
+### hasProperty(key: string): Promise\<Value\>
 
 If this element is an object of some sort, does it have the property matching key? Note this is an async function.
 
@@ -616,7 +616,7 @@ If this element is an object of some sort, does it have the property matching ke
 context.assert(await element.hasProperty("qa-name")).equals(true);
 ```
 
-### hover(): Promise<void>;
+### hover(): Promise\<void\>;
 
 Hover over this element with the virtual mouse.
 
@@ -680,7 +680,7 @@ jsonData.item("meta.count").assert().greaterThan(0);
 
 Convert the input to a array and join it into a string, return the resulting iValue;
 
-### load(): Promise<Scenario>
+### load(): Promise\<Scenario\>
 
 Load works basically the same way as `.click()`, so you should see the documentation on that.
 
@@ -788,7 +788,7 @@ array
   .every((name) => typeof name === "string");
 ```
 
-### press(key: string, opts?: any): Promise<void>;
+### press(key: string, opts?: any): Promise\<void\>;
 
 Press these keys on the keyboard.
 
@@ -800,11 +800,11 @@ Loop through the array or object items with reduce. Returns the final result.
 const totalPrice = rows.every((t, row) => t + row.quantity * row.unitPrice, 0);
 ```
 
-### screenshot(): Promise<Buffer>
+### screenshot(): Promise\<Buffer\>
 
 This is currently only supported with browser type scenarios. See documentation for `context.screenshot()` because the arguments are the same. The only difference is calling it on an Element will grab the image just of this element.
 
-### scrollTo(): Promise<void>;
+### scrollTo(): Promise\<void\>;
 
 For browser-based scenarios, scroll this element into view.
 
@@ -825,7 +825,7 @@ const anyAreActive = rows.some((row) => row.isActive);
 
 Convert the input to a string and split it into an array, return the resulting iValue;
 
-### submit(): Promise<Scenario>
+### submit(): Promise\<Scenario\>
 
 Load works basically the same way as `.click()` and `.load()`, so you can reference the documentation on those.
 
@@ -857,7 +857,7 @@ If the input is an array of objects, the argument then should be the key of the 
 const totalCount = rows.sum("quantity");
 ```
 
-### tap(): Promise<void>;
+### tap(): Promise\<void\>;
 
 Tap the element.
 
@@ -881,7 +881,7 @@ Casts the input value as a string.
 
 Grabs the type of the input value. It will be all lowercase and is a deep type look up, beyond a normal typeof.
 
-### type(textToType: string, opts: any): Promise<void>
+### type(textToType: string, opts: any): Promise\<void\>
 
 Type this text into an text input. This will not have any effect if the element is not a form text input.
 

--- a/docs/scenario.md
+++ b/docs/scenario.md
@@ -36,7 +36,7 @@ scenario.before((scenario: Scenario) => {
 
 Write a comment line to the output log.
 
-### execute(): Promise<Scenario>
+### execute(): Promise\<Scenario\>
 
 A scenario will automatically execute, unless told otherwise by the `.wait()` method, once it has the necessary properties set to do so. Namely, it must know the URL to open (with the `.open(...)` method) and have at least one `.next()` block to run tests against.
 
@@ -101,7 +101,7 @@ If a value was previously saved on this Scenario `set` or within an Assertion, V
 console.log(scenario.get("foo"));
 ```
 
-### getLog(): Promise<iLogLine[]>
+### getLog(): Promise\<iLogLine[]\>
 
 Return the logs from each line of the test, including passes, fails, and comments.
 
@@ -252,7 +252,7 @@ scenario
   });
 ```
 
-### promise(): Promise<Scenario>
+### promise(): Promise\<Scenario\>
 
 Promisifies the Scenario. The returned promise will resolve once the scenario completes successfully.
 
@@ -267,7 +267,7 @@ try {
 }
 ```
 
-### server(): Promise<WebhookServer>
+### server(): Promise\<WebhookServer\>
 
 If you read the `webhook()` documentation here, there is a bit of gap. You can use that method to set up a local HTTP server to wait for an incoming request before kicking off a test scenario. However, you can have that `webhook` method pick your port for you, and that happens asynchronously. So how will you know the resulting port?
 
@@ -420,7 +420,7 @@ scenario.setRawBody("what up");
 
 Set the request timeout for how long to wait for a response.
 
-### skip(message?: string): Promise<Scenario>
+### skip(message?: string): Promise\<Scenario\>
 
 Sometimes, perhaps based on the results from a previous scenario in the suite, we want to skip a certain scenario. All scenarios must be completed in one way or another, in order for the parent suite to complete. So if we determine that a certain scenario should not run, we use skip. It will appear in the output as skipped and will not count as failed or passed.
 
@@ -489,7 +489,7 @@ Sometimes you may NOT want to execute a scenario until another scenario has succ
 scenario2.waitFor(scenario1);
 ```
 
-### waitForFinished(): Promise<void>;
+### waitForFinished(): Promise\<void\>;
 
 Wait for this scenario to complete, either success or failure.
 
@@ -497,7 +497,7 @@ Wait for this scenario to complete, either success or failure.
 await scenario.waitForFinished();
 ```
 
-### waitForResponse(): Promise<void>;
+### waitForResponse(): Promise\<void\>;
 
 Wait for the response to come back from the scenario's HTTP request.
 

--- a/docs/suite.md
+++ b/docs/suite.md
@@ -128,7 +128,7 @@ Prints the results from the test execution to the console. This is often run ins
 suite.finally((suite) => suite.print(false));
 ```
 
-### promise(): Promise<Scenario>
+### promise(): Promise\<Scenario\>
 
 Promisifies the Suite. The returned promise will resolve once all scenarios in the suite complete successfully.
 


### PR DESCRIPTION
Today, in the docs, if you search for a method that returns a promise and click on the result in the sidebar, the page won't nav to that method. 

This is because the docsify markdown `Promise<foo>` will convert it to an HTML element and the target ID gets all messed up. Idk how it works exactly in the search, but I know this fixed it. 