### PR TITLE
Clean XML subscenario title

### DIFF
--- a/src/logging/flagpolereport.ts
+++ b/src/logging/flagpolereport.ts
@@ -159,7 +159,7 @@ export class FlagpoleReport {
 
       log.forEach((item: iLogItem) => {
         if (item.className === "heading") {
-          subScenarioTitle = item.message;
+          subScenarioTitle = this.cleanXMLCharacters(item.message);
         }
 
         if (item.type.startsWith("result")) {


### PR DESCRIPTION
We need to sanitize any forbidden characters out of an XML Flagpole report. I missed the subscenario titles when I did it the first time.

## Old:
```
<testcase id="Subscenario title &" name="With undefined and assertion titles"></testcase>
```
![Screen Shot 2021-10-20 at 2 16 58 PM](https://user-images.githubusercontent.com/46609057/138148883-208409ab-f7df-4bb9-a5bb-f908d2b6a5b2.png)

## New:
```
<testcase id="Subscenario title &amp;" name="With undefined and assertion titles"></testcase>
```
![Screen Shot 2021-10-20 at 2 18 10 PM](https://user-images.githubusercontent.com/46609057/138149009-2e8a31e6-5d48-4f92-ac66-103b6efa3156.png)



