### PR TITLE
Log XML report to the console

### DIFF
--- a/src/cli/testrunner.ts
+++ b/src/cli/testrunner.ts
@@ -222,8 +222,12 @@ export class TestRunner {
         "utf8"
       );
 
+      // write XML report to the file system
       template = template.replace("${output}", output);
       writeFileSync(filePath, template);
+
+      // also log it to the console
+      Cli.log(template);
 
       if (this.allPassing) {
         Cli.log("All suites passed.");


### PR DESCRIPTION
A change I made earlier had XML writing only to the file system and left the console empty. I thought it was a clean approach. I have an issue where CircleCI is failing to parse the XML, so not only can I not read the report in the CircleCI UI, but I don't have it in the console either. 

## Changes
Write the XML report to the console so we can inspect it in the event of a XML parsing failure. 