### PR TITLE
Added ability to get page source

### DIFF
--- a/docs/assertion-context.md
+++ b/docs/assertion-context.md
@@ -486,7 +486,7 @@ Get properties of screen of device under tests. Currently only works with Appium
 const screenProperties = await context.getScreenProperties();
 ```
 
-### getSource(): Promise\<iValue\>
+### getSource(): ValuePromise
 
 Get HTML or XML representation of current page or viewport.
 Currently only works to get XML of Appium viewport.

--- a/docs/assertion-context.md
+++ b/docs/assertion-context.md
@@ -486,6 +486,15 @@ Get properties of screen of device under tests. Currently only works with Appium
 const screenProperties = await context.getScreenProperties();
 ```
 
+### getSource(): Promise\<iValue\>
+
+Get HTML or XML representation of current page or viewport.
+Currently only works to get XML of Appium viewport.
+
+```javascript
+const source = await context.getSource();
+```
+
 ### hideKeyboard(): Promise\<void\>
 
 Hide onscreen keyboard. Currently only works in Appium scenarios. Does not work on iOS unless the keyboard on the device under test has a dedicated dismiss button.

--- a/src/appium/appiumresponse.ts
+++ b/src/appium/appiumresponse.ts
@@ -369,13 +369,15 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  public async getSource(): Promise<iValue> {
-    const res = await this.get("source");
-    return wrapAsValue(
-      this.context,
-      res.jsonRoot.value,
-      "XML source for current viewport"
-    );
+  public getSource(): ValuePromise {
+    return ValuePromise.execute(async () => {
+      const res = await this.get("source");
+      return wrapAsValue(
+        this.context,
+        res.jsonRoot.value,
+        "XML source for current viewport"
+      );
+    });
   }
 
   public async get(suffix: string): Promise<any> {

--- a/src/appium/appiumresponse.ts
+++ b/src/appium/appiumresponse.ts
@@ -369,6 +369,12 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
+  public async getSource(): Promise<string> {
+    const res = await this.get("source");
+
+    return res.jsonRoot.value;
+  }
+
   public async get(suffix: string): Promise<any> {
     return sendAppiumRequest(
       this.scenario,

--- a/src/appium/appiumresponse.ts
+++ b/src/appium/appiumresponse.ts
@@ -369,10 +369,15 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  public async getSource(): Promise<string> {
-    const res = await this.get("source");
-
-    return res.jsonRoot.value;
+  public get body(): Promise<iValue> {
+    return (async () => {
+      const res = await this.get("source");
+      return wrapAsValue(
+        this.context,
+        res.jsonRoot.value,
+        "XML source for current viewport"
+      );
+    })();
   }
 
   public async get(suffix: string): Promise<any> {

--- a/src/appium/appiumresponse.ts
+++ b/src/appium/appiumresponse.ts
@@ -369,15 +369,13 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  public get body(): Promise<iValue> {
-    return (async () => {
-      const res = await this.get("source");
-      return wrapAsValue(
-        this.context,
-        res.jsonRoot.value,
-        "XML source for current viewport"
-      );
-    })();
+  public async getSource(): Promise<iValue> {
+    const res = await this.get("source");
+    return wrapAsValue(
+      this.context,
+      res.jsonRoot.value,
+      "XML source for current viewport"
+    );
   }
 
   public async get(suffix: string): Promise<any> {

--- a/src/assertioncontext.ts
+++ b/src/assertioncontext.ts
@@ -658,8 +658,10 @@ export class AssertionContext implements iAssertionContext {
     await this.response.hideKeyboard();
   }
 
-  public async getSource(): Promise<iValue> {
-    return await this.response.getSource();
+  public getSource(): ValuePromise {
+    return ValuePromise.execute(async () => {
+      return await this.response.getSource();
+    });
   }
 
   protected async _findAllForSelectors(

--- a/src/assertioncontext.ts
+++ b/src/assertioncontext.ts
@@ -658,6 +658,10 @@ export class AssertionContext implements iAssertionContext {
     await this.response.hideKeyboard();
   }
 
+  public async getSource(): Promise<iValue> {
+    return await this.response.getSource();
+  }
+
   protected async _findAllForSelectors(
     selectors: string[],
     a?: string | FindAllOptions | RegExp,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -434,7 +434,7 @@ export interface iResponse {
   rotate(rotation: string | number): Promise<string | number>;
   getScreenProperties(): Promise<ScreenProperties>;
   hideKeyboard(): Promise<void>;
-  getSource(): Promise<iValue>;
+  getSource(): ValuePromise;
 }
 
 export interface iAssertionIs {
@@ -722,7 +722,7 @@ export interface iAssertionContext {
   rotate(rotation: string | number): Promise<string | number>;
   getScreenProperties(): Promise<ScreenProperties>;
   hideKeyboard(): Promise<void>;
-  getSource(): Promise<iValue>;
+  getSource(): ValuePromise;
 }
 export interface iSuite {
   scenarios: Array<iScenario>;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -339,7 +339,7 @@ export interface iResponse {
   responseTypeName: string;
   statusCode: iValue;
   statusMessage: iValue;
-  body: iValue | Promise<iValue>;
+  body: iValue;
   jsonBody: iValue;
   url: iValue; // The URL initially requested
   finalUrl: iValue; // The URL after any redirects
@@ -434,6 +434,7 @@ export interface iResponse {
   rotate(rotation: string | number): Promise<string | number>;
   getScreenProperties(): Promise<ScreenProperties>;
   hideKeyboard(): Promise<void>;
+  getSource(): Promise<iValue>;
 }
 
 export interface iAssertionIs {
@@ -721,6 +722,7 @@ export interface iAssertionContext {
   rotate(rotation: string | number): Promise<string | number>;
   getScreenProperties(): Promise<ScreenProperties>;
   hideKeyboard(): Promise<void>;
+  getSource(): Promise<iValue>;
 }
 export interface iSuite {
   scenarios: Array<iScenario>;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -339,7 +339,7 @@ export interface iResponse {
   responseTypeName: string;
   statusCode: iValue;
   statusMessage: iValue;
-  body: iValue;
+  body: iValue | Promise<iValue>;
   jsonBody: iValue;
   url: iValue; // The URL initially requested
   finalUrl: iValue; // The URL after any redirects

--- a/src/response.ts
+++ b/src/response.ts
@@ -232,7 +232,7 @@ export abstract class ProtoResponse implements iResponse {
     return this.httpResponse.body;
   }
 
-  public async getSource(): Promise<iValue> {
+  public getSource(): ValuePromise {
     throw new Error(
       `This scenario type (${this.responseTypeName}) does not support getSource.`
     );

--- a/src/response.ts
+++ b/src/response.ts
@@ -88,7 +88,7 @@ export abstract class ProtoResponse implements iResponse {
   /**
    * Raw Response Body
    */
-  public get body(): iValue | Promise<iValue> {
+  public get body(): iValue {
     return wrapAsValue(
       this.context,
       this.httpResponse.body,
@@ -230,6 +230,12 @@ export abstract class ProtoResponse implements iResponse {
 
   public getRoot(): any {
     return this.httpResponse.body;
+  }
+
+  public async getSource(): Promise<iValue> {
+    throw new Error(
+      `This scenario type (${this.responseTypeName}) does not support getSource.`
+    );
   }
 
   /**

--- a/src/response.ts
+++ b/src/response.ts
@@ -88,7 +88,7 @@ export abstract class ProtoResponse implements iResponse {
   /**
    * Raw Response Body
    */
-  public get body(): iValue {
+  public get body(): iValue | Promise<iValue> {
     return wrapAsValue(
       this.context,
       this.httpResponse.body,
@@ -464,7 +464,7 @@ export abstract class ProtoResponse implements iResponse {
   public async getScreenProperties(): Promise<ScreenProperties> {
     throw "getScreenProperties not implemented for this kind of scenario.";
   }
-  
+
   public async hideKeyboard(): Promise<void> {
     throw "hideKeyboard not implemented for this kind of scenario.";
   }


### PR DESCRIPTION
Get XML page source for current viewport. Useful as a helper method for scrolling until an element is present or until scrolling cannot be done anymore.