### PR TITLE
Appium clear and enter text by selector

### DIFF
--- a/src/appium/appiumresponse.ts
+++ b/src/appium/appiumresponse.ts
@@ -361,6 +361,39 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
     return res.jsonRoot.value;
   }
 
+  public type(
+    selector: string,
+    textToType: string,
+    opts: any = {}
+  ): ValuePromise {
+    return ValuePromise.execute(async () => {
+      let element = await this.find(selector, opts);
+      element = await element.type(textToType);
+
+      return element;
+    });
+  }
+
+  public clear(selector: string): ValuePromise {
+    return ValuePromise.execute(async () => {
+      let element = await this.find(selector);
+      element = await element.clear();
+      return element;
+    });
+  }
+
+  public clearThenType(
+    selector: string,
+    textToType: string,
+    opts: any = {}
+  ): ValuePromise {
+    return ValuePromise.execute(async () => {
+      let element = await this.clear(selector);
+      element = await this.type(selector, textToType, opts);
+      return element;
+    });
+  }
+
   private async _setImplicitWait(ms: number): Promise<void> {
     await this.post("timeouts/implicit_wait", {
       ms: ms,

--- a/src/appium/appiumresponse.ts
+++ b/src/appium/appiumresponse.ts
@@ -366,20 +366,13 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
     textToType: string,
     opts: any = {}
   ): ValuePromise {
-    return ValuePromise.execute(async () => {
-      let element = await this.find(selector, opts);
-      element = await element.type(textToType);
-
-      return element;
-    });
+    return ValuePromise.execute(async () =>
+      this.find(selector, opts).type(textToType)
+    );
   }
 
   public clear(selector: string): ValuePromise {
-    return ValuePromise.execute(async () => {
-      let element = await this.find(selector);
-      element = await element.clear();
-      return element;
-    });
+    return ValuePromise.execute(async () => this.find(selector).clear());
   }
 
   public clearThenType(
@@ -387,13 +380,9 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
     textToType: string,
     opts: any = {}
   ): ValuePromise {
-    return ValuePromise.execute(async () => {
-      let element = await this.find(selector, opts);
-      element = await element.clear();
-      element = await element.type(textToType);
-
-      return element;
-    });
+    return ValuePromise.execute(async () =>
+      this.find(selector, opts).clear().type(textToType)
+    );
   }
 
   private async _setImplicitWait(ms: number): Promise<void> {

--- a/src/appium/appiumresponse.ts
+++ b/src/appium/appiumresponse.ts
@@ -388,8 +388,10 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
     opts: any = {}
   ): ValuePromise {
     return ValuePromise.execute(async () => {
-      let element = await this.clear(selector);
-      element = await this.type(selector, textToType, opts);
+      let element = await this.find(selector, opts);
+      element = await element.clear();
+      element = await element.type(textToType);
+
       return element;
     });
   }

--- a/src/appium/appiumresponse.ts
+++ b/src/appium/appiumresponse.ts
@@ -381,7 +381,7 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
     opts: any = {}
   ): ValuePromise {
     return ValuePromise.execute(async () =>
-      this.find(selector, opts).clear().type(textToType)
+      this.find(selector).clear().type(textToType, opts)
     );
   }
 

--- a/src/assertioncontext.ts
+++ b/src/assertioncontext.ts
@@ -199,7 +199,7 @@ export class AssertionContext implements iAssertionContext {
     textToType: string,
     opts: any = {}
   ): ValuePromise {
-    return this.clearThenType(selector, textToType, opts);
+    return this.response.clearThenType(selector, textToType, opts);
   }
 
   /**


### PR DESCRIPTION
Creating this PR now because it fixes an issue with calling `clearThenType()` on the assertioncontext.