### PR TITLE
Appium ios get attribute

### DIFF
--- a/docs/ivalue.md
+++ b/docs/ivalue.md
@@ -489,8 +489,11 @@ Get the attribute of the element with this key and return its value. If it is no
 const src = await img.getAttribute("src");
 ```
 
-This also works with Appium testing. Valid attributes for Appium elements are:
-checkable, checked, class, className, clickable, content-desc, contentDescription, enabled, focusable, focused, long-clickable, longClickable, package, password, resource-id, resourceId, scrollable, selection-start, selection-end, selected, text, name, bounds, displayed, contentSize
+This also works with Appium testing.  
+Valid attributes for Android Appium elements are:  
+checkable, checked, class, className, clickable, content-desc, contentDescription, enabled, focusable, focused, long-clickable, longClickable, package, password, resource-id, resourceId, scrollable, selection-start, selection-end, selected, text, name, bounds, displayed, contentSize  
+Valid attributes for iOS Appium elements are:  
+accessibilityContainer, accessible, enabled, frame, index, label, name, rect, selected, type, value, visible, wdAccessibilityContainer, wdAccessible, wdEnabled, wdFrame, wdIndex, wdLabel, wdName, wdRect, wdSelected, wdType, wdUID, wdValue, wdVisible"
 
 ### getBounds(boxType?: string): Promise\<iBounds | null\>;
 

--- a/src/appium/appium-element.ts
+++ b/src/appium/appium-element.ts
@@ -371,7 +371,7 @@ export class AppiumElement extends DOMElement implements iValue {
   }
 
   protected async _getAttribute(key: string): Promise<string | null> {
-    const possibleAttributes = [
+    const possibleAttributesAndroid = [
       "checkable",
       "checked",
       "class",
@@ -399,8 +399,40 @@ export class AppiumElement extends DOMElement implements iValue {
       "contentSize",
     ];
 
-    if (!possibleAttributes.includes(key)) {
-      throw `Invalid attribute: must be one of ${possibleAttributes.join(
+    const possibleAttributesIos = [
+      "accessibilityContainer",
+      "accessible",
+      "enabled",
+      "frame",
+      "index",
+      "label",
+      "name",
+      "rect",
+      "selected",
+      "type",
+      "value",
+      "visible",
+      "wdAccessibilityContainer",
+      "wdAccessible",
+      "wdEnabled",
+      "wdFrame",
+      "wdIndex",
+      "wdLabel",
+      "wdName",
+      "wdRect",
+      "wdSelected",
+      "wdType",
+      "wdUID",
+      "wdValue",
+      "wdVisible",
+    ];
+
+    if (this.session.isAndroid && !possibleAttributesAndroid.includes(key)) {
+      throw `Invalid attribute: must be one of ${possibleAttributesAndroid.join(
+        ", "
+      )}`;
+    } else if (this.session.isIos && !possibleAttributesIos.includes(key)) {
+      throw `Invalid attribute: must be one of ${possibleAttributesIos.join(
         ", "
       )}`;
     }

--- a/src/appium/appium-response.ts
+++ b/src/appium/appium-response.ts
@@ -68,14 +68,14 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
     });
   }
 
-  protected get _isAndroid(): boolean {
+  public get isAndroid(): boolean {
     return (
       this.capabilities?.automationName?.toLowerCase() === "uiautomator2" ||
       this.capabilities?.automationName?.toLowerCase() === "espresso"
     );
   }
 
-  protected get _isIos(): boolean {
+  public get isIos(): boolean {
     return this.capabilities?.automationName?.toLowerCase() === "xcuitest";
   }
 
@@ -186,7 +186,7 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
           using: "text",
           value: params.contains,
         });
-      } else if (this._isIos) {
+      } else if (this.isIos) {
         res = await this.post("elements", {
           using: "-ios predicate string",
           value: `label == "${params.contains}"`,
@@ -481,11 +481,11 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
   // Uses deprecated JSONWP call
   public async isAppInstalled(bundleId: string): Promise<boolean> {
     let res = new JsonDoc("");
-    if (this._isAndroid) {
+    if (this.isAndroid) {
       res = await this.post("appium/device/app_installed", {
         bundleId: bundleId,
       });
-    } else if (this._isIos) {
+    } else if (this.isIos) {
       res = await this.post("execute", {
         script: "mobile: isAppInstalled",
         args: [
@@ -531,7 +531,7 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
       altitude: location.altitude,
     };
     // Android
-    if (this._isAndroid) {
+    if (this.isAndroid) {
       const wifiState: number = await sendAdbCommand(
         this.sessionId,
         this.context.scenario,
@@ -564,7 +564,7 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
         airplaneMode: airplaneModeState == 0 ? false : true,
       };
       // iOS
-    } else if (this._isIos) {
+    } else if (this.isIos) {
       const wifiState = await this._siriQueryAndResponse("Wi-Fi");
       const dataState = await this._siriQueryAndResponse("Cellular Data");
       const locationSvcsState = await this._siriQueryAndResponse(
@@ -644,7 +644,7 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
     app: string,
     timeout?: number
   ): Promise<void | boolean> {
-    if (this._isAndroid) {
+    if (this.isAndroid) {
       if (timeout) {
         await this.post("appium/device/terminate_app", {
           appId: app,
@@ -658,7 +658,7 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
         });
       }
       // This call is not deprecated
-    } else if (this._isIos) {
+    } else if (this.isIos) {
       const res = await this.post("execute", {
         script: "mobile: terminateApp",
         args: [{ bundleId: app }],
@@ -731,10 +731,10 @@ export class AppiumResponse extends ProtoResponse implements iResponse {
     args?: string[],
     environment?: any
   ): Promise<void> {
-    if (this._isAndroid) {
+    if (this.isAndroid) {
       await this.post("appium/app/launch", {});
       // This call is not deprecated
-    } else if (this._isIos) {
+    } else if (this.isIos) {
       if (!app) throw "App bundleId required for launching an iOS app";
 
       await this.post("execute", {


### PR DESCRIPTION
iOS didn't work using Android attributes. Unbeknownst to me previously, there is a whole set of other attributes for iOS. This now checks the appropriate attributes based on what you are testing. I also made isAndroid and isIos public methods so I could call them from an AppiumElement